### PR TITLE
1. Bug Fixed for null value:

### DIFF
--- a/ios/Classes/FlutterTxugcuploadPlugin.m
+++ b/ios/Classes/FlutterTxugcuploadPlugin.m
@@ -151,9 +151,9 @@
                 @"result": @{
                         @"retCode": @(videoResult.retCode),
                         @"descMsg": videoResult.descMsg != nil ? videoResult.descMsg : @"",
-                        @"videoId": videoResult.videoId,
-                        @"videoURL": videoResult.videoURL,
-                        @"coverURL": videoResult.coverURL,
+                        @"videoId": videoResult.videoId != nil ? videoResult.videoId : @"",
+                        @"videoURL": videoResult.videoURL != nil ? videoResult.videoURL : @"",
+                        @"coverURL": videoResult.coverURL != nil ? videoResult.coverURL : @"",
                 }
         }
     };


### PR DESCRIPTION
Situation: Internet unavaliable or user calls cancel  when uploading.
Crashed Reason: The TX_SDK will send back NULL value for URL and so on when canceling. Should add SAFE func.